### PR TITLE
Обновление docker-compose.elasticsearch.yaml

### DIFF
--- a/docker-compose.elasticsearch.yaml
+++ b/docker-compose.elasticsearch.yaml
@@ -7,6 +7,8 @@ services:
     ports:
       - 19200:9200
       - 15601:5601
+    networks:
+      - data-engineering-labs-network
 
 networks:
   data-engineering-labs-network:


### PR DESCRIPTION
Необходимо явно добавить сервис с elastic-search в сеть, иначе он не цепляет в докер сетевую-связку